### PR TITLE
chore: update node and pnpm versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # https://github.com/pnpm/action-setup/releases/tag/v6.0.8
         with:
-          version: 10.33.2
+          version: 11.1.2
           run_install: false
 
       - name: Resolve pnpm cache dependency paths

--- a/.github/workflows/release-stable-plugin.yml
+++ b/.github/workflows/release-stable-plugin.yml
@@ -187,7 +187,7 @@ jobs:
         if: matrix.needs_node_toolchain
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # https://github.com/pnpm/action-setup/releases/tag/v6.0.8
         with:
-          version: 10.33.2
+          version: 11.1.2
           run_install: false
 
       - name: Resolve pnpm cache dependency paths

--- a/js-modules/shiki/package.json
+++ b/js-modules/shiki/package.json
@@ -22,7 +22,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": "^10.33.2"
+        "pnpm": "^11.1.2"
     },
-    "packageManager": "pnpm@10.33.2"
+    "packageManager": "pnpm@11.1.2"
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "type": "module",
     "engines": {
         "node": ">=24",
-        "pnpm": "^10.33.2"
+        "pnpm": "^11.1.2"
     },
-    "packageManager": "pnpm@10.33.2",
+    "packageManager": "pnpm@11.1.2",
     "scripts": {
         "sync:changelog-links": "node .github/scripts/update-changelog-links.js"
     }

--- a/ui/package.json
+++ b/ui/package.json
@@ -55,7 +55,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": "^10.33.2"
+        "pnpm": "^11.1.2"
     },
-    "packageManager": "pnpm@10.33.2"
+    "packageManager": "pnpm@11.1.2"
 }


### PR DESCRIPTION
This PR updates the repository toolchain versions tracked in:
- `package.json`
- `ui/package.json`
- `js-modules/shiki/package.json`
- workflows that bootstrap Node.js and pnpm directly

Releases are only considered eligible after a 1 day delay, matching the repository's Dependabot cooldown.

Resolved by automation:
- Node.js LTS major: `24`
- pnpm version: `11.1.2`