### PR TITLE
chore: update node and pnpm versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # https://github.com/pnpm/action-setup/releases/tag/v6.0.9
         with:
-          version: 11.13.0
+          version: 11.17.0
           run_install: false
 
       - name: Resolve pnpm cache dependency paths

--- a/.github/workflows/release-stable-plugin.yml
+++ b/.github/workflows/release-stable-plugin.yml
@@ -187,7 +187,7 @@ jobs:
         if: matrix.needs_node_toolchain
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # https://github.com/pnpm/action-setup/releases/tag/v6.0.9
         with:
-          version: 11.13.0
+          version: 11.17.0
           run_install: false
 
       - name: Resolve pnpm cache dependency paths

--- a/js-modules/shiki/package.json
+++ b/js-modules/shiki/package.json
@@ -22,7 +22,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": "^11.13.0"
+        "pnpm": "^11.17.0"
     },
-    "packageManager": "pnpm@11.13.0"
+    "packageManager": "pnpm@11.17.0"
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "type": "module",
     "engines": {
         "node": ">=24",
-        "pnpm": "^11.13.0"
+        "pnpm": "^11.17.0"
     },
-    "packageManager": "pnpm@11.13.0",
+    "packageManager": "pnpm@11.17.0",
     "scripts": {
         "sync:changelog-links": "node .github/scripts/update-changelog-links.js"
     }

--- a/ui/package.json
+++ b/ui/package.json
@@ -57,7 +57,7 @@
     },
     "engines": {
         "node": ">=24",
-        "pnpm": "^11.13.0"
+        "pnpm": "^11.17.0"
     },
-    "packageManager": "pnpm@11.13.0"
+    "packageManager": "pnpm@11.17.0"
 }


### PR DESCRIPTION
This PR updates the repository toolchain versions tracked in:
- `package.json`
- `ui/package.json`
- `js-modules/shiki/package.json`
- workflows that bootstrap Node.js and pnpm directly

Releases are only considered eligible after a 1 day delay, matching the repository's Dependabot cooldown.

Resolved by automation:
- Node.js LTS major: `24`
- pnpm version: `11.17.0`